### PR TITLE
fix: harden v3 to v4 migration pipeline

### DIFF
--- a/src/core/migrations/001_v3-to-v4-multifile.js
+++ b/src/core/migrations/001_v3-to-v4-multifile.js
@@ -14,13 +14,15 @@ export const migration = {
   },
 
   apply(config, _context) {
+    const sanitizedConfig = sanitizeOptionalV3Selectors(config);
+
     // Normalize to a v3-schema view (handles both v1 and v3 input)
-    const normalized = normalizeRouterSchemaV3(config);
+    const normalized = normalizeRouterSchemaV3(sanitizedConfig);
 
     // Extract active preset/catalog from the original config (prefer raw values)
     const active_preset =
-      config.active_preset ??
-      config.active_profile ??
+      sanitizedConfig.active_preset ??
+      sanitizedConfig.active_profile ??
       normalized.activePresetName ??
       null;
 
@@ -55,6 +57,96 @@ export const migration = {
     return { coreConfig, profiles };
   },
 };
+
+function sanitizeOptionalV3Selectors(config) {
+  if (!config || typeof config !== 'object') {
+    return config;
+  }
+
+  const next = JSON.parse(JSON.stringify(config));
+  for (const key of ['active_catalog', 'active_preset', 'active_profile']) {
+    if (!(key in next)) {
+      continue;
+    }
+
+    const value = next[key];
+    if (typeof value !== 'string') {
+      delete next[key];
+      continue;
+    }
+
+    const trimmed = value.trim();
+    if (trimmed.length === 0) {
+      delete next[key];
+      continue;
+    }
+
+    next[key] = trimmed;
+  }
+
+  normalizeV3PhaseObjects(next);
+
+  return next;
+}
+
+function normalizeV3PhaseObjects(config) {
+  if (config.version !== 3 || !config.catalogs || typeof config.catalogs !== 'object') {
+    return;
+  }
+
+  for (const catalog of Object.values(config.catalogs)) {
+    if (!catalog || typeof catalog !== 'object' || !catalog.presets || typeof catalog.presets !== 'object') {
+      continue;
+    }
+
+    for (const preset of Object.values(catalog.presets)) {
+      if (!preset || typeof preset !== 'object' || !preset.phases || typeof preset.phases !== 'object') {
+        continue;
+      }
+
+      for (const [phaseName, phaseValue] of Object.entries(preset.phases)) {
+        if (Array.isArray(phaseValue) || !phaseValue || typeof phaseValue !== 'object') {
+          continue;
+        }
+
+        const model = typeof phaseValue.model === 'string' ? phaseValue.model.trim() : '';
+        if (!model) {
+          continue;
+        }
+
+        const lane = {
+          target: model,
+          phase: phaseName,
+          role: 'primary',
+        };
+        const fallbacks = normalizeFallbacks(phaseValue.fallbacks);
+        if (fallbacks.length > 0) {
+          lane.fallbacks = fallbacks;
+        }
+
+        preset.phases[phaseName] = [lane];
+      }
+    }
+  }
+}
+
+function normalizeFallbacks(value) {
+  if (Array.isArray(value)) {
+    return value
+      .filter((item) => typeof item === 'string')
+      .map((item) => item.trim())
+      .filter((item) => item.length > 0);
+  }
+
+  if (typeof value === 'string') {
+    return value
+      .split(',')
+      .map((item) => item.trim())
+      .filter((item) => item.length > 0);
+  }
+
+  return [];
+}
 
 /**
  * Convert a normalized preset object back into the v3 wire format

--- a/src/core/migrations/002_profile-schema-simplification.js
+++ b/src/core/migrations/002_profile-schema-simplification.js
@@ -39,7 +39,7 @@ export const migration = {
    */
   canApply(coreConfig, profilesArray = []) {
     // Condition 1: active_preset is present and non-empty
-    if (typeof coreConfig.active_preset === 'string' && coreConfig.active_preset.length > 0) {
+    if (typeof coreConfig.active_preset === 'string' && coreConfig.active_preset.trim().length > 0) {
       return true;
     }
 
@@ -65,7 +65,10 @@ export const migration = {
     const updatedCore = JSON.parse(JSON.stringify(coreConfig));
     const inputProfiles = JSON.parse(JSON.stringify(profilesArray));
 
-    const activePreset = updatedCore.active_preset ?? null;
+    const activePreset =
+      typeof updatedCore.active_preset === 'string'
+        ? updatedCore.active_preset.trim()
+        : null;
 
     // Step 2: Set visible:true on the profile matching active_preset
     if (activePreset) {

--- a/src/core/migrations/index.js
+++ b/src/core/migrations/index.js
@@ -376,8 +376,17 @@ export async function runMigrations(routerDir, options = {}) {
 
   const applied = [];
   const backups = [];
+  let finalPlan = plan;
 
-  for (const pendingMigration of plan.pending) {
+  while (true) {
+    const currentPlan = planMigrations(routerDir);
+    finalPlan = currentPlan;
+    const pendingMigration = currentPlan.pending[0];
+
+    if (!pendingMigration) {
+      break;
+    }
+
     // Find the full migration script object
     const script = MIGRATIONS.find((m) => m.id === pendingMigration.id);
     if (!script) {
@@ -439,7 +448,7 @@ export async function runMigrations(routerDir, options = {}) {
     }
   }
 
-  return { applied, backups, plan };
+  return { applied, backups, plan: finalPlan };
 }
 
 // ─── Exports ─────────────────────────────────────────────────────────────────

--- a/test/migration-001.test.js
+++ b/test/migration-001.test.js
@@ -82,6 +82,26 @@ const V3_CONFIG_MULTI_CATALOG = {
   },
 };
 
+const V3_CONFIG_PHASE_OBJECTS = {
+  version: 3,
+  active_catalog: 'default',
+  active_preset: 'cheap',
+  catalogs: {
+    default: {
+      presets: {
+        cheap: {
+          phases: {
+            orchestrator: {
+              model: 'openai/gpt-oss-20b',
+              fallbacks: ['google/gemma-3-27b'],
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
 const V1_CONFIG = {
   version: 1,
   active_profile: 'default',
@@ -136,6 +156,17 @@ describe('migration 001: canApply', () => {
 // ─── apply: v3 monolith ───────────────────────────────────────────────────────
 
 describe('migration 001: apply on v3 config', () => {
+  test('tolerates null active selectors by resolving a fallback preset', () => {
+    const dirtyConfig = {
+      ...V3_CONFIG,
+      active_preset: null,
+      active_profile: null,
+    };
+
+    const { coreConfig } = migration.apply(dirtyConfig, {});
+    assert.equal(coreConfig.active_preset, 'balanced');
+  });
+
   test('produces coreConfig with version 4', () => {
     const { coreConfig } = migration.apply(V3_CONFIG, {});
     assert.equal(coreConfig.version, 4);
@@ -199,6 +230,14 @@ describe('migration 001: apply on v3 config', () => {
 
     assert.ok(edge, 'edge profile exists');
     assert.equal(edge.catalog, 'experimental');
+  });
+
+  test('accepts v3 phase objects with model/fallbacks and migrates them', () => {
+    const { profiles } = migration.apply(V3_CONFIG_PHASE_OBJECTS, {});
+    assert.equal(profiles.length, 1);
+    const orchestrator = profiles[0].content.phases.orchestrator;
+    assert.ok(Array.isArray(orchestrator), 'phase migrated into lane array format');
+    assert.equal(orchestrator[0].target, 'openai/gpt-oss-20b');
   });
 });
 

--- a/test/migration-002.test.js
+++ b/test/migration-002.test.js
@@ -273,6 +273,13 @@ describe('migration 002: canApply', () => {
       false
     );
   });
+
+  test('returns false when active_preset contains only whitespace', () => {
+    assert.equal(
+      migration.canApply({ version: 4, active_preset: '   ' }, []),
+      false
+    );
+  });
 });
 
 // ─── apply: active_preset handling ───────────────────────────────────────────

--- a/test/migrations.test.js
+++ b/test/migrations.test.js
@@ -459,7 +459,40 @@ profiles:
           role: primary
 `;
 
+const V3_ROUTER_YAML_NO_ACTIVE_PRESET = `version: 3
+active_catalog: default
+activation_state: active
+catalogs:
+  default:
+    presets:
+      balanced:
+        phases:
+          orchestrator:
+            - target: anthropic/claude-sonnet
+              phase: orchestrator
+              role: primary
+`;
+
 describe('runMigrations: full migration flow (v3 → v4)', () => {
+  test('re-plans and applies 002 after 001 when v3 input omits active_preset', async () => {
+    const dir = makeTempDir();
+
+    try {
+      writeRouterYaml(dir, V3_ROUTER_YAML_NO_ACTIVE_PRESET);
+
+      const result = await runMigrations(dir);
+
+      assert.ok(result.applied.includes('001'), 'migration 001 was applied');
+      assert.ok(result.applied.includes('002'), 'migration 002 was applied after re-plan');
+
+      const raw = fs.readFileSync(path.join(dir, 'router.yaml'), 'utf8');
+      assert.ok(raw.includes('version: 4'), 'router.yaml has version: 4 after migrations');
+      assert.ok(!raw.includes('active_preset:'), 'active_preset removed by migration 002');
+    } finally {
+      cleanup(dir);
+    }
+  });
+
   test('applies migration and returns applied list', async () => {
     const dir = makeTempDir();
 


### PR DESCRIPTION
## Summary
- Harden migration `001` to tolerate invalid v3 selectors (`active_preset`, `active_profile`, `active_catalog`) and normalize object-style phase definitions into lane arrays before normalization.
- Make migration `002` ignore whitespace-only `active_preset` values and trim selector handling to avoid false positives.
- Update `runMigrations` to re-plan iteratively after each applied step so dependent migrations (like `002` after `001`) are not skipped.

## Changes
- Updated migration logic in `src/core/migrations/001_v3-to-v4-multifile.js`, `src/core/migrations/002_profile-schema-simplification.js`, and `src/core/migrations/index.js`.
- Added regression tests for null/whitespace selectors, object-style v3 phases, and iterative migration execution in `test/migration-001.test.js`, `test/migration-002.test.js`, and `test/migrations.test.js`.

## Testing
- [x] `node --test test/migration-001.test.js`
- [x] `node --test test/migration-002.test.js`
- [x] `node --test test/migrations.test.js`